### PR TITLE
Fix small typo in pagination documentation section

### DIFF
--- a/resources/views/api/includes/pagination.blade.php
+++ b/resources/views/api/includes/pagination.blade.php
@@ -4,7 +4,7 @@
     <div class="section-block" style="">
         <p>Requests for collections can return between 0 and 100 results, controlled using the <code>limit</code> and <code>page</code> query parameters. All end points are limited to 10 results by default.</p>
 <pre class="language-javascript">
-<code>GET /api/drugs?lmit=5&amp;page=2
+<code>GET /api/drugs?limit=5&amp;page=2
 </code>
 </pre>
         <p>Not all endpoints support pagination. If they do, it will be mentioned in their documentation.</p>


### PR DESCRIPTION
The pagination documentation is instructing to use `limit` query parameter while the example is written `GET /api/drugs?lmit=5&page=2` which does not work and is against the instructions. What works is `GET /api/drugs?limit=5&page=2`